### PR TITLE
Attempt to fix seasonal display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -135,7 +135,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { determineSeason } from './utils/utils'
+import { determineSeason, seasonsOfCurrentYear } from './utils/utils'
 import { DateTime } from 'luxon'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
@@ -160,8 +160,8 @@ const breeds: Array<
       backgroundColour: '106, 162, 171',
       accentColour: '4, 63, 181',
       availability: season.name === 'winter',
-      begin: season.begin,
-      end: season.end
+      begin: seasonsOfCurrentYear(d)['winter'].start,
+      end: seasonsOfCurrentYear(d)['winter'].end
     }
   },
 
@@ -174,8 +174,8 @@ const breeds: Array<
       backgroundColour: '106, 162, 171',
       accentColour: '4, 63, 181',
       availability: season.name === 'spring',
-      begin: season.begin,
-      end: season.end
+      begin: seasonsOfCurrentYear(d)['spring'].start,
+      end: seasonsOfCurrentYear(d)['spring'].end
     }
   },
 
@@ -188,8 +188,8 @@ const breeds: Array<
       backgroundColour: '106, 162, 171',
       accentColour: '4, 63, 181',
       availability: season.name === 'summer',
-      begin: season.begin,
-      end: season.end
+      begin: seasonsOfCurrentYear(d)['summer'].start,
+      end: seasonsOfCurrentYear(d)['summer'].end
     }
   },
 
@@ -202,8 +202,8 @@ const breeds: Array<
       backgroundColour: '106, 162, 171',
       accentColour: '4, 63, 181',
       availability: season.name === 'autumn',
-      begin: season.begin,
-      end: season.end
+      begin: seasonsOfCurrentYear(d)['autumn'].start,
+      end: seasonsOfCurrentYear(d)['autumn'].end
     }
   },
 
@@ -299,8 +299,8 @@ const forecast = computed(() => {
         ...result,
         begin,
         end,
-        appearing: result.availability && startDiff > -1,
-        leaving: result.availability && endDiff < 1
+        appearing: startDiff > 0 && startDiff < 1,
+        leaving: endDiff < 1 && endDiff > 0
       }
     })
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -73,6 +73,33 @@ export function determineSeason(date: DateTime): {
   throw new Error('unable to deduce season')
 }
 
+export function seasonsOfCurrentYear(date: DateTime) {
+  const previousYear = mapJDSeasonsToDateTime(getJDSolsticesAndEquinoxes(date.year - 1))
+  const currentYear = mapJDSeasonsToDateTime(getJDSolsticesAndEquinoxes(date.year))
+  const nextYear = mapJDSeasonsToDateTime(getJDSolsticesAndEquinoxes(date.year + 1))
+
+  const seasons = {
+    winter: {
+      start: date < currentYear.marchEquinox ? previousYear.decemberSolstice : currentYear.decemberSolstice,
+      end: date < currentYear.marchEquinox ? currentYear.marchEquinox : nextYear.marchEquinox,
+    },
+    spring: {
+      start: currentYear.marchEquinox,
+      end: currentYear.juneSolstice
+    },
+    summer: {
+      start: currentYear.juneSolstice,
+      end: currentYear.septemberEquinox
+    },
+    autumn: {
+      start: currentYear.septemberEquinox,
+      end: currentYear.decemberSolstice
+    }
+  }
+
+  return seasons;
+}
+
 export function jdToDateTime(jD: number, zone?: Zone) {
   return DateTime.fromJSDate(julian.JDToDate(jD), { zone })
 }


### PR DESCRIPTION
- Introduced a new `seasonsOfCurrentYear` function that takes the current year and returns an object with the start and end dates of all four seasons for that year.
- Fixed the `breeds` array return value to get their `begin` and `end` date values from the result of `seasonsOfCurrentYear`.
- Adjustment to the expressions determining the `appearing` and `leaving` properties of the `results` breeds.