### PR TITLE
Fix indexing error on dates before timestamp

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -123,7 +123,7 @@ export function mapJDSeasonsToDateTime(jDSeasons: JDSeasonalCycle): Seasons {
  * @param colour 0 = gold, 1 = blue, 2 = silver
  */
 export function sonataProbability(d: DateTime, colour: number): number {
-  const ts = Math.floor(((d.toMillis() / 100000 - 16835652) / 864) % 128);
+  const ts = Math.floor(((((d.toMillis() / 100000 - 16835652) / 864) % 128) + 128) % 128);
   return moon.sonata[ts][colour];
 }
 
@@ -133,6 +133,6 @@ export function sonataProbability(d: DateTime, colour: number): number {
  * @returns The herald colour. 0 = Silver, 1 = Gold, 2 = Bronze, 3 = Indigo
  */
 export function heraldColour(d: DateTime): number {
-  const ts = Math.floor(((d.toMillis() / 100000 - 16833924) / 864) % 32);
+  const ts = Math.floor(((((d.toMillis() / 100000 - 16833924) / 864) % 32) + 32) % 32);
   return moon.herald[ts];
 }


### PR DESCRIPTION
Dates before the timestamp in the file would trigger an index error as the % operator in JavaScript is remainder, not modulo.